### PR TITLE
getElementById  returns null

### DIFF
--- a/system/expressionengine/third_party/structure_nav/libraries/Structure_nav_parser.php
+++ b/system/expressionengine/third_party/structure_nav/libraries/Structure_nav_parser.php
@@ -34,6 +34,11 @@ class Structure_nav_parser
 
         unset($structure);
 
+        if($html == null)
+        {
+            return false;
+        }
+
         $dom = new DOMDocument();
 
         $dom->loadHTML('<!doctype html>'.$html);

--- a/system/expressionengine/third_party/structure_nav/libraries/Structure_nav_parser.php
+++ b/system/expressionengine/third_party/structure_nav/libraries/Structure_nav_parser.php
@@ -36,7 +36,7 @@ class Structure_nav_parser
 
         $dom = new DOMDocument();
 
-        $dom->loadHTML($html);
+        $dom->loadHTML('<!doctype html>'.$html);
 
         $ul = $dom->getElementById('nav-sub');
 

--- a/system/expressionengine/third_party/structure_nav/pi.structure_nav.php
+++ b/system/expressionengine/third_party/structure_nav/pi.structure_nav.php
@@ -43,9 +43,12 @@ class Structure_nav
 
         $variables = $nav->get_variables();
 
-        unset($nav);
+        if($variables)
+        {
+            unset($nav);
 
-        return ee()->TMPL->parse_variables(ee()->TMPL->tagdata, $variables);
+            return ee()->TMPL->parse_variables(ee()->TMPL->tagdata, $variables);
+        }
     }
 
     public function advanced()
@@ -54,9 +57,12 @@ class Structure_nav
 
         $variables = $nav->get_variables(true);
 
-        unset($nav);
+        if($variables)
+        { 
+            unset($nav);
 
-        return ee()->TMPL->parse_variables(ee()->TMPL->tagdata, $variables);
+            return ee()->TMPL->parse_variables(ee()->TMPL->tagdata, $variables);
+        }
     }
 }
 


### PR DESCRIPTION
In some cases the getElementById method in "structure_nav_parser.php" returns "NULL" when you dont give an doctype.

See http://php.net/manual/en/domdocument.getelementbyid.php#100402

By adding the doctype this will fix this issue.
